### PR TITLE
Add model field to slash command frontmatter for cost optimization

### DIFF
--- a/.claude/templates/COMMAND_TEMPLATE.md
+++ b/.claude/templates/COMMAND_TEMPLATE.md
@@ -11,6 +11,7 @@ This template defines the standard structure for slash commands in `essentials/c
 allowed-tools: <Tool1, Tool2, ...>
 argument-hint: "<argument pattern>"
 description: <One-line description>
+model: <haiku|opus>  # Optional: haiku for loops/cancels, opus for creators
 context: fork  # Optional: runs command in isolated context (use for heavy exploration commands)
 ---
 
@@ -185,6 +186,7 @@ Use `subagent_type: "<agent-type>"` and `run_in_background: true`.
 - `allowed-tools`: Comma-separated list of tools the command can use
 - `argument-hint`: Pattern showing expected arguments (e.g., `<file1> [file2]`)
 - `description`: Single-line description for help text
+- Optional: `model: <haiku|opus>` for explicit model selection (haiku for loops/cancels, opus for creators)
 - Optional: `context: fork` for commands that spawn heavy background agents (isolates context from main session)
 - Optional: `hide-from-slash-command-tool: "true"` for internal commands
 

--- a/essentials/commands/beads-creator.md
+++ b/essentials/commands/beads-creator.md
@@ -2,6 +2,7 @@
 allowed-tools: Task, TaskOutput, Bash, Read, Glob
 argument-hint: "<spec-path> [spec-path-2] [spec-path-3] ..."
 description: Convert OpenSpec specs to self-contained Beads (project)
+model: opus
 ---
 
 # Beads Creator

--- a/essentials/commands/beads-loop.md
+++ b/essentials/commands/beads-loop.md
@@ -1,6 +1,7 @@
 ---
 description: "Execute beads iteratively until all tasks complete"
 argument-hint: "[--step|--auto] [--label <label>] [--max-iterations N]"
+model: haiku
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-beads-loop.sh)", "Read", "TodoWrite", "Bash", "Edit", "AskUserQuestion"]
 hide-from-slash-command-tool: "true"
 ---

--- a/essentials/commands/bug-plan-creator.md
+++ b/essentials/commands/bug-plan-creator.md
@@ -2,6 +2,7 @@
 allowed-tools: Task, TaskOutput, Bash, Read
 argument-hint: <any-input>
 description: Deep bug investigation with architectural fix plan generation - detailed enough to feed directly into /implement-loop or OpenSpec
+model: opus
 context: fork
 ---
 

--- a/essentials/commands/cancel-beads.md
+++ b/essentials/commands/cancel-beads.md
@@ -2,6 +2,7 @@
 allowed-tools: Bash
 argument-hint: ""
 description: Cancel active beads loop
+model: haiku
 ---
 
 # Cancel Beads

--- a/essentials/commands/cancel-implement.md
+++ b/essentials/commands/cancel-implement.md
@@ -2,6 +2,7 @@
 allowed-tools: Bash
 argument-hint: ""
 description: Cancel active implement loop
+model: haiku
 ---
 
 # Cancel Implement

--- a/essentials/commands/cancel-spec-loop.md
+++ b/essentials/commands/cancel-spec-loop.md
@@ -1,6 +1,7 @@
 ---
 allowed-tools: Bash
 description: Cancel active spec loop
+model: haiku
 ---
 
 # Cancel Spec Loop

--- a/essentials/commands/code-quality-plan-creator.md
+++ b/essentials/commands/code-quality-plan-creator.md
@@ -2,6 +2,7 @@
 allowed-tools: Task, TaskOutput
 argument-hint: "<file1> [file2] ... [fileN]"
 description: LSP-powered architectural code quality analysis - generates comprehensive improvement plans for /implement-loop or OpenSpec
+model: opus
 context: fork
 ---
 

--- a/essentials/commands/codemap-creator.md
+++ b/essentials/commands/codemap-creator.md
@@ -2,6 +2,7 @@
 allowed-tools: Task, TaskOutput
 argument-hint: "[directory] [--ignore <patterns>]"
 description: Generate comprehensive code maps with LSP for symbol tracking and reference verification (project)
+model: opus
 context: fork
 ---
 

--- a/essentials/commands/document-creator.md
+++ b/essentials/commands/document-creator.md
@@ -2,6 +2,7 @@
 allowed-tools: Task, TaskOutput
 argument-hint: "[directory-or-files]"
 description: Generate DEVGUIDE.md architectural documentation using LSP (project)
+model: opus
 context: fork
 ---
 

--- a/essentials/commands/implement-loop.md
+++ b/essentials/commands/implement-loop.md
@@ -1,6 +1,7 @@
 ---
 description: "Implement a plan with iterative loop until completion"
 argument-hint: "<plan_path> [--step|--auto] [--max-iterations N]"
+model: haiku
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-implement-loop.sh)", "Read", "TodoWrite", "Bash", "Edit", "AskUserQuestion"]
 hide-from-slash-command-tool: "true"
 ---

--- a/essentials/commands/mr-description-creator.md
+++ b/essentials/commands/mr-description-creator.md
@@ -2,6 +2,7 @@
 allowed-tools: Task, TaskOutput, Bash, Read, Glob, Grep, AskUserQuestion
 argument-hint: "[--template 'markdown']"
 description: Generate and apply MR/PR description directly via gh or glab CLI (project)
+model: opus
 skills: ["github-cli", "gitlab-cli"]
 ---
 

--- a/essentials/commands/plan-creator.md
+++ b/essentials/commands/plan-creator.md
@@ -2,6 +2,7 @@
 allowed-tools: Task, TaskOutput
 argument-hint: <task-description>
 description: Create a comprehensive architectural plan for any task - detailed enough to feed directly into /implement-loop or OpenSpec
+model: opus
 context: fork
 ---
 

--- a/essentials/commands/prompt-creator.md
+++ b/essentials/commands/prompt-creator.md
@@ -2,6 +2,7 @@
 allowed-tools: Task, TaskOutput, Bash, Read, AskUserQuestion
 argument-hint: <description>
 description: Create high-quality prompts from any description (project)
+model: opus
 ---
 
 # Prompt Creator

--- a/essentials/commands/proposal-creator.md
+++ b/essentials/commands/proposal-creator.md
@@ -2,6 +2,7 @@
 allowed-tools: Task, TaskOutput, Bash, Read, Glob, Grep
 argument-hint: "[plan-path-or-description]"
 description: Convert plans, context, or descriptions into validated OpenSpec proposals (project)
+model: opus
 context: fork
 ---
 

--- a/essentials/commands/spec-loop.md
+++ b/essentials/commands/spec-loop.md
@@ -1,6 +1,7 @@
 ---
 description: "Implement an OpenSpec change iteratively until all tasks complete"
 argument-hint: "<change-id> [--step|--auto] [--max-iterations N]"
+model: haiku
 allowed-tools: ["Bash(${CLAUDE_PLUGIN_ROOT}/scripts/setup-spec-loop.sh)", "Read", "TodoWrite", "Bash", "Edit", "AskUserQuestion"]
 hide-from-slash-command-tool: "true"
 ---


### PR DESCRIPTION
## Summary

- Add explicit `model:` field to all slash command frontmatter for cost-optimized execution
- Loop commands (`beads-loop`, `implement-loop`, `spec-loop`) use `model: haiku` for faster/cheaper iterative execution
- Cancel commands use `model: haiku` for lightweight operations
- Creator commands (9 files) use `model: opus` for complex reasoning tasks
- Update `COMMAND_TEMPLATE.md` to document the new optional model field

## Test plan

- [ ] Verify loop commands execute with haiku model
- [ ] Verify creator commands execute with opus model
- [ ] Verify YAML frontmatter is valid in all modified files

## Verification

```bash
# All 15 commands have model field
grep -l "^model:" essentials/commands/*.md | wc -l  # Expected: 15

# 6 files have model: haiku (loops + cancels)
grep -l "model: haiku" essentials/commands/*.md | wc -l  # Expected: 6

# 9 files have model: opus (creators)
grep -l "model: opus" essentials/commands/*.md | wc -l  # Expected: 9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)